### PR TITLE
Fix variable error on first-load of example.php

### DIFF
--- a/example.php
+++ b/example.php
@@ -112,9 +112,12 @@ if (isSet($_GET['query']))
 	}
 else
 	$resout = '';
+	$whois = array();
+	$whois['CODE_VERSION'] = '';
+	$out = str_replace('{ver}',$whois['CODE_VERSION'],$out);
+	exit(str_replace('{results}', $resout, $out));
 
-$out = str_replace('{ver}',$whois->CODE_VERSION,$out);
-exit(str_replace('{results}', $resout, $out));
+
 
 //-------------------------------------------------------------------------
 


### PR DESCRIPTION
There were errors on first load of the example.php file, which were as follows:

- Undefined variable at (Line 115)
- Trying to get property of non-object (Line 115)
- Trying to get property of non-object (Line 119)

These errors have now been fixed.

**Before**
![2016-03-26](https://cloud.githubusercontent.com/assets/8210764/14062744/507cc400-f3a2-11e5-802d-a0bc46b440ca.png)

**After**
![2016-03-26 1](https://cloud.githubusercontent.com/assets/8210764/14062748/778b6e8e-f3a2-11e5-9e66-781475bc70d7.png)

